### PR TITLE
Fix _find_matching_end braces/brackets

### DIFF
--- a/frangiclave/csjson.py
+++ b/frangiclave/csjson.py
@@ -30,18 +30,24 @@ def _move_to_next_node(json: str, begin: int, end: int) -> int:
 
 
 def _find_matching_end(json: str, begin: int, end: int) -> int:
-    num = 0
+    num_braces = 0
+    num_brackets = 0
     flag = False
     for i in range(begin, end):
         c = json[i]
         if i == 0 or json[i - 1] != '\\':
             if c == '"':
                 flag = not flag
-            elif c == '{' or c == '[':
-                num += 1
-            elif c == '}' or c == ']':
-                num -= 1
-                if num == 0:
+            elif not flag:
+                if c == '{':
+                    num_braces += 1
+                elif c == '[':
+                    num_brackets += 1
+                elif c == '}':
+                    num_braces -= 1
+                elif c == ']':
+                    num_brackets -= 1
+                if num_braces == 0 and num_brackets == 0:
                     return i
     return end
 


### PR DESCRIPTION
_find_matching_end was slightly broken, in that it:
1. would treat `[1, 2, 3}` as a valid, complete sequence
2. got confused on unquoted values terminated with a `}`, so it parsed `signalEndingFlavour: Melancholy},` in long_recipes_attacks.json:113 as `"signalEndingFlavour": "Melancholy},\n"`, didn't treat it as a hashmap terminator, and merged the keys from the following hashmap into that.



With the patch, it counts brackets and braces separately, and ignores them within strings. That way, the key in `longassault.assassination.killplayer` is parsed as `"signalEndingFlavour": "Melancholy"` and terminated there, so the following hashmap is correctly considered separate.