### PR TITLE
Use pathlib and JSOM, make game files importable from a Linux build

### DIFF
--- a/frangiclave/csjson.py
+++ b/frangiclave/csjson.py
@@ -1,5 +1,7 @@
 from typing import Any, List, Dict, Union, Tuple, TextIO
 
+# Left here for now; should I delete it?
+
 
 def load(fh: TextIO) -> Union[Dict[str, Any], List[Any]]:
     return loads(fh.read())

--- a/frangiclave/exporter.py
+++ b/frangiclave/exporter.py
@@ -2,6 +2,9 @@ from typing import List, Tuple, Union, Dict, Any, Optional
 
 from collections import OrderedDict, defaultdict
 
+from pathlib import Path
+import platform
+
 import json
 import toml
 
@@ -19,6 +22,10 @@ from frangiclave.server import app
 from frangiclave.main import CONFIG_FILE_NAME, load_config
 
 config = load_config(CONFIG_FILE_NAME)
+
+DATA_DIR = (
+    'cultistsimulator_Data' if platform.system() == 'Windows' else 'CS_Data'
+)
 
 
 def export_compendium(session: Session) -> Any:
@@ -64,11 +71,11 @@ def export_compendium(session: Session) -> Any:
             content[category] = objs
             
             output_string = json.dumps(content, indent=4)
-            game_dir_base = config["frangiclave"]["GAME_DIRECTORY"]
-            game_dir_cont = "cultistsimulator_Data\\StreamingAssets\\content\\"
-            f = open(game_dir_base + game_dir_cont + file.group.value + "\\" + file.category.value + "\\" + file.name, "w")
-            f.write(output_string)
-            f.close()
+            game_dir_base = Path(config["frangiclave"]["GAME_DIRECTORY"])
+            game_dir_cont = game_dir_base/DATA_DIR/'StreamingAssets'/'content'
+            with (game_dir_cont/file.group.value/file.category).open("w") as f:
+                f.write(output_string)
+
 
 def dict_one_item(item, category):
     if category == "recipes":

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
     install_requires=[
         'flask',
         'sqlalchemy',
-        'toml'
+        'toml',
+        'jsom==0.0.5'
     ],
     extras_require={},
     include_package_data=True,


### PR DESCRIPTION
Pull request up for evaluation and verification. Three changes in one:

1. The importer and exporter now use [pathlib](https://docs.python.org/3/library/pathlib.html) (which is a *fantastic* library) instead of building paths by concatenating strings, because it:
   1. Is cross-platform (I'm not sure building paths with `"\\"` works on Unix/Linux/MacOS)
   2. Looks nicer: (`game_dir_base + game_dir_cont + file.group.value + "\\" + file.category.value + "\\" + file.name`) vs `game_dir_base/game_dir_cont/file.group.value/file.category.value`
2. The importer now uses [jsom](https://github.com/slavfox/jsom), as promised :D It is able to parse the entire game properly without workarounds on my system, requesting verification on this.
3.  Since the paths are now OS-agnostic, the last thing that was needed for the importer to work on Linux was changing the hardcoded `"cultistsimulator_Data"` to be `"CS_Data"` on non-Windows systems (I'm guessing that's what it is on macOS as well, but not sure).